### PR TITLE
Configure API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://ms-gateway-production-97bb.up.railway.app

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the variables as needed:
+
+```bash
+cp .env.example .env
+```
+
+Set `VITE_API_BASE_URL` to the base URL of the backend API in the `.env` file. The application uses this variable when making requests via the helper in `src/api.js`.

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,4 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+export const apiFetch = (path, options) =>
+  fetch(`${API_BASE_URL}${path}`, options);
+export { API_BASE_URL };

--- a/src/views/TaskDetails.jsx
+++ b/src/views/TaskDetails.jsx
@@ -1,13 +1,14 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { FaIdBadge, FaClipboardList, FaAlignLeft, FaInfoCircle } from "react-icons/fa";
+import { apiFetch } from "../api";
 
 function TaskDetails() {
   const { id } = useParams();
   const [tarea, setTarea] = useState(null);
 
   useEffect(() => {
-    fetch(`https://ms-gateway-production-97bb.up.railway.app/task/api/tasks/id/${id}`)
+    apiFetch(`/task/api/tasks/id/${id}`)
       .then((res) => res.json())
       .then((data) => setTarea(data))
       .catch((error) => console.error("Error al cargar la tarea:", error));

--- a/src/views/TaskForm.jsx
+++ b/src/views/TaskForm.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { FaPlusCircle, FaRegFileAlt, FaAlignLeft } from "react-icons/fa";
 import { toast } from "react-toastify";
 import useForm from "../hooks/useForm";
+import { apiFetch } from "../api";
 
 function TaskForm() {
   const [formData, handleChange] = useForm({
@@ -14,7 +15,7 @@ function TaskForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch("https://ms-gateway-production-97bb.up.railway.app/task/api/tasks", {
+      const res = await apiFetch("/task/api/tasks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),

--- a/src/views/Tasks.jsx
+++ b/src/views/Tasks.jsx
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { apiFetch } from "../api";
 
 function Tasks() {
   const [tareas, setTareas] = useState([]);
@@ -12,7 +13,7 @@ function Tasks() {
   const [tareasFiltradas, setTareasFiltradas] = useState([]);
 
   useEffect(() => {
-    fetch("https://ms-gateway-production-97bb.up.railway.app/task/api/tasks")
+    apiFetch("/task/api/tasks")
       .then((res) => res.json())
       .then((data) => {
         const ordenadas = data.sort((a, b) => a.id - b.id);

--- a/src/views/UserDetails.jsx
+++ b/src/views/UserDetails.jsx
@@ -1,13 +1,14 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { FaIdBadge, FaUser, FaEnvelope, FaMobileAlt, FaUserCircle } from "react-icons/fa";
+import { apiFetch } from "../api";
 
 function UserDetails() {
   const { id } = useParams();
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    fetch(`https://ms-gateway-production-97bb.up.railway.app/task/api/taskuser/id/${id}`)
+    apiFetch(`/task/api/taskuser/id/${id}`)
       .then((res) => res.json())
       .then((data) => setUser(data))
       .catch((error) => console.error("Error loading user:", error));

--- a/src/views/UserForm.jsx
+++ b/src/views/UserForm.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { FaUser, FaEnvelope, FaMobileAlt, FaUserPlus } from "react-icons/fa";
 import { toast } from "react-toastify";
 import useForm from "../hooks/useForm";
+import { apiFetch } from "../api";
 
 function UserForm() {
   const [formData, handleChange] = useForm({
@@ -15,7 +16,7 @@ function UserForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch("https://ms-gateway-production-97bb.up.railway.app/task/api/taskuser", {
+      const res = await apiFetch("/task/api/taskuser", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),

--- a/src/views/Users.jsx
+++ b/src/views/Users.jsx
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { apiFetch } from "../api";
 
 
 function Users() {
@@ -13,7 +14,7 @@ function Users() {
   const [usuarios, setUsuarios] = useState([]);
 
   useEffect(() => {
-    fetch("https://ms-gateway-production-97bb.up.railway.app/task/api/taskuser")
+    apiFetch("/task/api/taskuser")
       .then((res) => res.json())
       .then((data) => setUsuarios(data))
       .catch((err) => console.error("Error al obtener usuarios:", err));


### PR DESCRIPTION
## Summary
- add example env file with VITE_API_BASE_URL
- centralize fetch logic in `src/api.js`
- use `apiFetch` helper throughout views
- document environment setup

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685d2b6a02688325aa379c393e0b2e1e